### PR TITLE
Fix remove duplicate translator twig plugin

### DIFF
--- a/src/Pyz/Zed/Twig/TwigDependencyProvider.php
+++ b/src/Pyz/Zed/Twig/TwigDependencyProvider.php
@@ -71,7 +71,6 @@ class TwigDependencyProvider extends SprykerTwigDependencyProvider
             new MoneyTwigPlugin(),
             new CurrencyTwigPlugin(),
             new ZedNavigationTwigPlugin(),
-            new TranslatorTwigPlugin(),
             new DateTimeFormatterTwigPlugin(),
             new SchedulerTwigPlugin(),
             new BarcodeTwigPlugin(),


### PR DESCRIPTION
There is a duplicate translator twig plugin loaded in zed's twig dependency provider which will cause a failure in a higher twig version.