### PR TITLE
SC-12058: CI. Upgrade Nodejs version 12 -> 16 and NPM 6 -> 8 into B2B/B2C deploy.ci.api.yml

### DIFF
--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -46,6 +46,9 @@ image:
     environment:
         SPRYKER_PRODUCT_CONFIGURATOR_HOST: date-time-configurator-example.cloud.spryker.toys
         SPRYKER_PRODUCT_CONFIGURATOR_PORT: 443
+    node:
+        version: 16
+        npm: 8
 composer:
     mode: --no-dev
     autoload: --classmap-authoritative

--- a/deploy.ci.api.mariadb.yml
+++ b/deploy.ci.api.mariadb.yml
@@ -10,6 +10,9 @@ image:
     environment:
         SPRYKER_PRODUCT_CONFIGURATOR_HOST: date-time-configurator-example.spryker.local
         SPRYKER_PRODUCT_CONFIGURATOR_PORT: 80
+    node:
+        version: 16
+        npm: 8
 composer:
     mode: --no-dev
     autoload: --classmap-authoritative

--- a/deploy.ci.api.yml
+++ b/deploy.ci.api.yml
@@ -10,6 +10,9 @@ image:
     environment:
         SPRYKER_PRODUCT_CONFIGURATOR_HOST: date-time-configurator-example.spryker.local
         SPRYKER_PRODUCT_CONFIGURATOR_PORT: 80
+    node:
+        version: 16
+        npm: 8
 composer:
     mode: --no-dev
     autoload: --classmap-authoritative

--- a/deploy.ci.functional.mariadb.yml
+++ b/deploy.ci.functional.mariadb.yml
@@ -10,6 +10,9 @@ image:
     environment:
         SPRYKER_PRODUCT_CONFIGURATOR_HOST: date-time-configurator-example.spryker.local
         SPRYKER_PRODUCT_CONFIGURATOR_PORT: 80
+    node:
+        version: 16
+        npm: 8
 composer:
     mode: --no-dev
     autoload: --classmap-authoritative

--- a/deploy.ci.functional.yml
+++ b/deploy.ci.functional.yml
@@ -10,6 +10,9 @@ image:
     environment:
         SPRYKER_PRODUCT_CONFIGURATOR_HOST: date-time-configurator-example.spryker.local
         SPRYKER_PRODUCT_CONFIGURATOR_PORT: 80
+    node:
+        version: 16
+        npm: 8
 composer:
     mode: --no-dev
     autoload: --classmap-authoritative


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/SC-12058

###### Change log

- updated node version to 16 into deploy.ci.api.yml
- updated npm version to 8 into deploy.ci.api.yml
