### PR TITLE
Bugfix: QuickOrderFileUpload label input reference

### DIFF
--- a/src/Pyz/Yves/QuickOrderPage/Theme/default/components/molecules/quick-order-file-upload/quick-order-file-upload.ts
+++ b/src/Pyz/Yves/QuickOrderPage/Theme/default/components/molecules/quick-order-file-upload/quick-order-file-upload.ts
@@ -42,7 +42,7 @@ export default class QuickOrderFileUpload extends Component {
         this.inputFile.value = '';
         this.fileUploadMessage.innerText = this.uploadMessage;
         this.toggleClassForIconExtensionMessage();
-        this.browseFileLabel.setAttribute('for', this.inputFileId.substring(1));
+        this.browseFileLabel.setAttribute('for', this.inputFileId);
     }
 
     protected toggleClassForIconExtensionMessage(): void {


### PR DESCRIPTION
Repeated file selection is prevented by incorrect reference of the input label. "input-file-id"-attribute already contains the correct name ("upload_order_form_fileUploadOrder") an not a selector ("#upload_order_form_fileUploadOrder")