### PR TITLE
Propose default-value for SPRYKER_OAUTH_CLIENT_CONFIGURATION

### DIFF
--- a/config/Shared/config_default.php
+++ b/config/Shared/config_default.php
@@ -245,7 +245,7 @@ $config[OauthConstants::PUBLIC_KEY_PATH]
         getenv('SPRYKER_OAUTH_KEY_PUBLIC') ?: '',
     ) ?: null;
 $config[OauthConstants::ENCRYPTION_KEY] = getenv('SPRYKER_OAUTH_ENCRYPTION_KEY') ?: null;
-$config[OauthConstants::OAUTH_CLIENT_CONFIGURATION] = json_decode(getenv('SPRYKER_OAUTH_CLIENT_CONFIGURATION'), true) ?: [];
+$config[OauthConstants::OAUTH_CLIENT_CONFIGURATION] = json_decode(getenv('SPRYKER_OAUTH_CLIENT_CONFIGURATION') ?: '', true) ?: [];
 
 // >> ZED REQUEST
 


### PR DESCRIPTION
default-value for SPRYKER_OAUTH_CLIENT_CONFIGURATION environment variable necessary to build application as spryker-sdk do not provide variable "SPRYKER_OAUTH_CLIENT_CONFIGURATION" to the Build pipeline.
