### PR TITLE
Update Jenkins version to 2.493.2 

### DIFF
--- a/deploy.aop-b2b-testing.yml
+++ b/deploy.aop-b2b-testing.yml
@@ -221,6 +221,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             jenkins.aop-b2b-testing.demo-spryker.com:

--- a/deploy.aop-consultant.yml
+++ b/deploy.aop-consultant.yml
@@ -219,6 +219,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.consultant.demo-spryker.com:

--- a/deploy.aop-demoshop-b2b.yml
+++ b/deploy.aop-demoshop-b2b.yml
@@ -190,6 +190,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.aop-b2b.demo-spryker.com:

--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -224,6 +224,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
+        version: '2.492.3'
         endpoints:
             scheduler.example.cloud.spryker.toys:
     mail_catcher:

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -113,7 +113,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -115,7 +115,7 @@ services:
         version: '6.8'
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
     mail_catcher:
         engine: mailhog

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -239,7 +239,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -210,7 +210,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -225,7 +225,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:

--- a/deploy.scos2-b2b.yml
+++ b/deploy.scos2-b2b.yml
@@ -159,7 +159,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: false
         endpoints:
             scheduler.spryker-b2b.cloud.spryker.toys:

--- a/deploy.spryker-scosb2b.yml
+++ b/deploy.spryker-scosb2b.yml
@@ -176,7 +176,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.scos-b2b.sh01.demo-spryker.com:

--- a/deploy.yml
+++ b/deploy.yml
@@ -217,7 +217,7 @@ services:
                 protocol: tcp
     scheduler:
         engine: jenkins
-        version: '2.442'
+        version: '2.492.3'
         csrf-protection-enabled: true
         endpoints:
             scheduler.spryker.local:


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-10275

###### Change log

- Introduce Jenkins 2.492.3 as the default scheduler version.
