### PR TITLE
OPS-4941 Updated RabbitMQ version.

### DIFF
--- a/deploy.aws-env-template.yml
+++ b/deploy.aws-env-template.yml
@@ -201,7 +201,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.dynamic-store-off.yml
@@ -138,7 +138,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.mariadb.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.cypress.yml
@@ -112,7 +112,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.cypress.yml
@@ -149,7 +149,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.robot.yml
@@ -142,7 +142,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.acceptance.mariadb.dynamic-store-off.yml
@@ -137,7 +137,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.acceptance.mariadb.prefer-lowest.yml
+++ b/deploy.ci.acceptance.mariadb.prefer-lowest.yml
@@ -100,7 +100,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.robot.yml
+++ b/deploy.ci.acceptance.mariadb.robot.yml
@@ -106,7 +106,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.mariadb.yml
+++ b/deploy.ci.acceptance.mariadb.yml
@@ -100,7 +100,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.robot.yml
+++ b/deploy.ci.acceptance.robot.yml
@@ -96,7 +96,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.acceptance.yml
+++ b/deploy.ci.acceptance.yml
@@ -96,7 +96,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.dynamic-store-off.yml
+++ b/deploy.ci.api.dynamic-store-off.yml
@@ -127,7 +127,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.api.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.api.mariadb.dynamic-store-off.yml
@@ -128,7 +128,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.api.mariadb.robot.yml
+++ b/deploy.ci.api.mariadb.robot.yml
@@ -102,7 +102,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.mariadb.yml
+++ b/deploy.ci.api.mariadb.yml
@@ -89,7 +89,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.api.yml
+++ b/deploy.ci.api.yml
@@ -89,7 +89,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.dynamic-store-off.yml
+++ b/deploy.ci.functional.dynamic-store-off.yml
@@ -114,7 +114,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.functional.mariadb.dynamic-store-off.yml
+++ b/deploy.ci.functional.mariadb.dynamic-store-off.yml
@@ -115,7 +115,7 @@ services:
             password: "secret"
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.ci.functional.mariadb.prefer-lowest.yml
+++ b/deploy.ci.functional.mariadb.prefer-lowest.yml
@@ -102,7 +102,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.mariadb.yml
+++ b/deploy.ci.functional.mariadb.yml
@@ -93,7 +93,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.ci.functional.yml
+++ b/deploy.ci.functional.yml
@@ -89,7 +89,7 @@ services:
             password: 'secret'
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.dev.dynamic-store-off.yml
+++ b/deploy.dev.dynamic-store-off.yml
@@ -216,7 +216,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.dev.yml
+++ b/deploy.dev.yml
@@ -187,7 +187,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'

--- a/deploy.dynamic-store-off.yml
+++ b/deploy.dynamic-store-off.yml
@@ -202,7 +202,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: "spryker"
             password: "secret"

--- a/deploy.yml
+++ b/deploy.yml
@@ -194,7 +194,7 @@ services:
                 protocol: tcp
     broker:
         engine: rabbitmq
-        version: '3.9'
+        version: '3.13'
         api:
             username: 'spryker'
             password: 'secret'


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/OPS-4941

###### Change log

- Updated RabbitMQ service version from 3.9 to 3.13 across all deployment configurations to ensure environment consistency and prevent version-related compatibility issues.
