### PR TITLE
FRW-9914 Enable parallel test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
                     sudo chmod +x /usr/local/bin/docker-compose
 
             -   name: Install Project
-                continue-on-error: true
+                continue-on-error: false
                 run: |
                     git clone https://github.com/spryker/docker-sdk.git ./docker
                     docker/sdk boot deploy.ci.acceptance.dynamic-store-off.yml
@@ -496,7 +496,7 @@ jobs:
                     sudo chmod +x /usr/local/bin/docker-compose
 
             -   name: Install Project
-                continue-on-error: true
+                continue-on-error: false
                 run: |
                     git clone https://github.com/spryker/docker-sdk.git ./docker
                     docker/sdk boot deploy.ci.api.mariadb.robot.yml

--- a/.github/workflows/robot-ui-e2e-tests.yml
+++ b/.github/workflows/robot-ui-e2e-tests.yml
@@ -1,4 +1,4 @@
-name: "[b2b][master] Robot Regression UI E2E"
+name: "Robot UI E2E"
 
 on:
     pull_request:
@@ -18,13 +18,13 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    docker-alpine-php-83-mariadb-robot-ui-group-one:
+    docker-alpine-php-83-mariadb-robot-ui:
         if: >
             (github.event_name == 'pull_request'
                 && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
                     || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
             ) || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ssp-master'
-        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI / Group One"
+        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI"
         runs-on: ubuntu-latest
         env:
             PROGRESS_TYPE: plain
@@ -67,188 +67,45 @@ jobs:
                     docker/sdk cli composer dump-autoload -o -a --apcu
                     docker/sdk console queue:worker:start --stop-when-empty
 
-            -   name: Run Tests
-                id: run_tests
+            -   name: Run Dynamic Tests Set
+                id: run_dynamic_tests
                 continue-on-error: true
                 run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v headless:true -v ignore_console:false -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local -v yves_env:http://yves.eu.spryker.local -v zed_env:http://backoffice.eu.spryker.local -d results --exclude skip-due-to-issueORskip-due-to-refactoring --include group_one -s '*'.tests.ui.b2b .
-                    docker/sdk exec robot-framework touch results/time.txt && echo $(date) > results/time.txt
-
-            -   name: Rerun Failed Tests
-                if: steps.run_tests.outcome != 'success'
+                    docker/sdk exec robot-framework pabot --processes 6 --ordering pabot_b2b_ordering -v env:ui_b2b -v is_ssp:true -v docker:True -v headless:true -v ignore_console:false -v dms:true -d results/dynamic_set --exclude skip-due-to-issueORskip-due-to-refactoringORstatic-set -s '*'.tests.parallel_ui.b2b .
+            -   name: Run Static Tests Set
+                id: run_static_tests
+                continue-on-error: true
                 run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v headless:true -v ignore_console:false -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local -v yves_env:http://yves.eu.spryker.local -v zed_env:http://backoffice.eu.spryker.local -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.ui.b2b .
-
-            -   name: Merge Test Results
-                if: always() && steps.run_tests.outcome != 'success'
+                    docker/sdk exec robot-framework robot -v env:ui_b2b -v is_ssp:true -v docker:True -v headless:true -v ignore_console:false -v dms:true -d results/static_set --exclude skip-due-to-issueORskip-due-to-refactoring --include static-set -s '*'.tests.parallel_ui.b2b .
+            -   name: Merge Initial Test Results
+                id: merge_initial_results
+                continue-on-error: true
+                run: |
+                    docker/sdk exec robot-framework rebot -d results --output output.xml --merge results/dynamic_set/output.xml results/static_set/output.xml
+            -   name: Rerun Failed Tests
+                id: rerun_failed_tests
+                if: always() && steps.merge_initial_results.outcome != 'success'
+                run: |
+                    docker/sdk exec robot-framework robot -v env:ui_b2b -v is_ssp:true -v docker:True -v dms:true -v headless:true -v ignore_console:false -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.parallel_ui.b2b .
+            -   name: Merge Final Test Results
+                if: always() && steps.merge_initial_results.outcome != 'success'
                 run: |
                     docker/sdk exec robot-framework rebot -d results --merge results/output.xml results/rerun/rerun.xml
-
             -   name: Upload artifacts
                 if: failure()
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-on/robot-ui/${GITHUB_RUN_ID}/PHP8.3MariaDB/group1/log.html
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-on/robot-ui/${GITHUB_RUN_ID}/PHP8.3MariaDB/log.html
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications
                 if: always()
 
-    docker-alpine-php-83-mariadb-robot-ui-group-two:
-        if: >
-            (github.event_name == 'pull_request'
-                && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
-                    || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
-            ) || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ssp-master'
-        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI /Group Two"
-        runs-on: ubuntu-latest
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.3
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-            SPRYKER_CURRENT_REGION: EU
-            DYNAMIC_STORE_MODE: true
-        steps:
-            -   uses: actions/checkout@v4
-
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt-get install -y python3-pip
-                    pip3 install --upgrade pip
-                    pip3 install awscli
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-
-            -   name: Install Project
-                continue-on-error: false
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.acceptance.mariadb.robot.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local queue.spryker.local scheduler.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local date-time-configurator-example.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-
-            -   name: Custom commands
-                continue-on-error: false
-                run: |
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    docker/sdk console queue:worker:start --stop-when-empty
-
-            -   name: Run Tests
-                id: run_tests
-                continue-on-error: true
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v headless:true -v ignore_console:false -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local -v yves_env:http://yves.eu.spryker.local -v zed_env:http://backoffice.eu.spryker.local -d results --exclude skip-due-to-issueORskip-due-to-refactoring --include group_two -s '*'.tests.ui.b2b .
-                    docker/sdk exec robot-framework touch results/time.txt && echo $(date) > results/time.txt
-
-            -   name: Rerun Failed Tests
-                if: steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v headless:true -v ignore_console:false -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local -v yves_env:http://yves.eu.spryker.local -v zed_env:http://backoffice.eu.spryker.local -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.ui.b2b .
-
-            -   name: Merge Test Results
-                if: always() && steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework rebot -d results --merge results/output.xml results/rerun/rerun.xml
-
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-on/robot-ui/${GITHUB_RUN_ID}/PHP8.3MariaDB/group2/log.html
-
-            -   name: Slack Notification for failed job
-                uses: ./.github/actions/job-slack-notifications
-                if: always()
-
-    docker-alpine-php-83-mariadb-robot-ui-group-three:
-        if: >
-            (github.event_name == 'pull_request'
-                && (contains(github.event.pull_request.labels.*.name, 'run-ui-ci')
-                    || contains(github.event.pull_request.labels.*.name, 'run-latest-ci'))
-            ) || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ssp-master'
-        name: "[run-ui-ci] PHP 8.3 / MariaDB / Robot / UI / Group Three"
-        runs-on: ubuntu-latest
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.3
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-            SPRYKER_CURRENT_REGION: EU
-            DYNAMIC_STORE_MODE: true
-        steps:
-            -   uses: actions/checkout@v4
-
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt-get install -y python3-pip
-                    pip3 install --upgrade pip
-                    pip3 install awscli
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-
-            -   name: Install Project
-                continue-on-error: false
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.acceptance.mariadb.robot.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.eu.spryker.local backend-api.us.spryker.local backend-gateway.eu.spryker.local backend-gateway.us.spryker.local backoffice.eu.spryker.local backoffice.us.spryker.local glue-backend.eu.spryker.local glue-backend.us.spryker.local glue-storefront.eu.spryker.local glue-storefront.us.spryker.local glue.eu.spryker.local glue.us.spryker.local mail.spryker.local queue.spryker.local scheduler.spryker.local spryker.local swagger.spryker.local yves.eu.spryker.local yves.us.spryker.local date-time-configurator-example.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-
-            -   name: Custom commands
-                continue-on-error: false
-                run: |
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    docker/sdk console queue:worker:start --stop-when-empty
-
-            -   name: Run Tests
-                id: run_tests
-                continue-on-error: true
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v headless:true -v ignore_console:false -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local -v yves_env:http://yves.eu.spryker.local -v zed_env:http://backoffice.eu.spryker.local -d results --exclude skip-due-to-issueORskip-due-to-refactoring --include group_tree -s '*'.tests.ui.b2b .
-                    docker/sdk exec robot-framework touch results/time.txt && echo $(date) > results/time.txt
-
-            -   name: Rerun Failed Tests
-                if: steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v headless:true -v ignore_console:false -v dms:true -v glue_env:http://glue.eu.spryker.local -v bapi_env:http://glue-backend.eu.spryker.local -v sapi_env:http://glue-storefront.eu.spryker.local -v yves_env:http://yves.eu.spryker.local -v zed_env:http://backoffice.eu.spryker.local -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.ui.b2b .
-
-            -   name: Merge Test Results
-                if: always() && steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework rebot -d results --merge results/output.xml results/rerun/rerun.xml
-
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-on/robot-ui/${GITHUB_RUN_ID}/PHP8.3MariaDB/group3/log.html
-
-            -   name: Slack Notification for failed job
-                uses: ./.github/actions/job-slack-notifications
-                if: always()
-
-    docker-alpine-php-82-postgresql-dynamic-store-off-robot-ui-group-one:
+    docker-alpine-php-82-postgresql-dynamic-store-off-robot-ui:
         if: >
             (github.event_name == 'pull_request'
                 && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
             ) || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ssp-master'
-        name: "Docker / Alpine / PHP 8.2 / PostgreSQL / Dynamic Store OFF / Robot / UI / Group One"
+        name: "Docker / Alpine / PHP 8.2 / PostgreSQL / Dynamic Store OFF / Robot / UI"
         runs-on: ubuntu-latest
         env:
             PROGRESS_TYPE: plain
@@ -290,173 +147,34 @@ jobs:
                     APPLICATION_STORE=DE docker/sdk console queue:worker:start --stop-when-empty
                     APPLICATION_STORE=AT docker/sdk console queue:worker:start --stop-when-empty
 
-            -   name: Run Tests
-                id: run_tests
+            -   name: Run Dynamic Tests Set
+                id: run_dynamic_tests
                 continue-on-error: true
                 run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results --exclude skip-due-to-issueORskip-due-to-refactoring --include group_one -s '*'.tests.ui.b2b .
-                    docker/sdk exec robot-framework touch results/time.txt && echo $(date) > results/time.txt
-
-            -   name: Rerun Failed Tests
-                if: steps.run_tests.outcome != 'success'
+                    docker/sdk exec robot-framework pabot --processes 6 --ordering pabot_b2b_ordering -v env:ui_b2b -v is_ssp:true -v docker:True -v headless:true -v ignore_console:false -v dms:false -v db_engine:psycopg2 -d results/dynamic_set --exclude skip-due-to-issueORskip-due-to-refactoringORstatic-set -s '*'.tests.parallel_ui.b2b .
+            -   name: Run Static Tests Set
+                id: run_static_tests
+                continue-on-error: true
                 run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.ui.b2b .
-
-            -   name: Merge Test Results
-                if: always() && steps.run_tests.outcome != 'success'
+                    docker/sdk exec robot-framework robot -v env:ui_b2b -v is_ssp:true -v docker:True -v headless:true -v ignore_console:false -v dms:false -v db_engine:psycopg2 -d results/static_set --exclude skip-due-to-issueORskip-due-to-refactoring --include static-set -s '*'.tests.parallel_ui.b2b .
+            -   name: Merge Initial Test Results
+                id: merge_initial_results
+                continue-on-error: true
+                run: |
+                    docker/sdk exec robot-framework rebot -d results --output output.xml --merge results/dynamic_set/output.xml results/static_set/output.xml
+            -   name: Rerun Failed Tests
+                id: rerun_failed_tests
+                if: always() && steps.merge_initial_results.outcome != 'success'
+                run: |
+                    docker/sdk exec robot-framework robot -v env:ui_b2b -v is_ssp:true -v docker:True -v dms:false -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.parallel_ui.b2b .
+            -   name: Merge Final Test Results
+                if: always() && steps.merge_initial_results.outcome != 'success'
                 run: |
                     docker/sdk exec robot-framework rebot -d results --merge results/output.xml results/rerun/rerun.xml
-
             -   name: Upload artifacts
                 if: failure()
                 run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-off/robot-ui/${GITHUB_RUN_ID}/PHP8.2MariaDB/group1/log.html
-
-            -   name: Slack Notification for failed job
-                uses: ./.github/actions/job-slack-notifications
-                if: always()
-
-    docker-alpine-php-82-postgresql-dynamic-store-off-robot-ui-group-two:
-        if: >
-            (github.event_name == 'pull_request'
-                && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
-            ) || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ssp-master'
-        name: "Docker / Alpine / PHP 8.2 / PostgreSQL / Dynamic Store OFF / Robot / UI / Group Two"
-        runs-on: ubuntu-latest
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.2
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-        steps:
-            -   uses: actions/checkout@v4
-
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt-get install -y python3-pip
-                    pip3 install --upgrade pip
-                    pip3 install awscli
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-
-            -   name: Install Project
-                continue-on-error: false
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.acceptance.dynamic-store-off.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.at.spryker.local backend-api.de.spryker.local glue-backend.de.spryker.local glue-backend.at.spryker.local glue-storefront.de.spryker.local glue-storefront.at.spryker.local backend-gateway.at.spryker.local backend-gateway.de.spryker.local backoffice.at.spryker.local backoffice.de.spryker.local date-time-configurator-example.spryker.local glue.at.spryker.local glue.de.spryker.local yves.at.spryker.local yves.de.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-
-            -   name: Custom commands
-                continue-on-error: false
-                run: |
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    APPLICATION_STORE=DE docker/sdk console queue:worker:start --stop-when-empty
-                    APPLICATION_STORE=AT docker/sdk console queue:worker:start --stop-when-empty
-
-            -   name: Run Tests
-                id: run_tests
-                continue-on-error: true
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results --exclude skip-due-to-issueORskip-due-to-refactoring --include group_two -s '*'.tests.ui.b2b .
-                    docker/sdk exec robot-framework touch results/time.txt && echo $(date) > results/time.txt
-
-            -   name: Rerun Failed Tests
-                if: steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.ui.b2b .
-
-            -   name: Merge Test Results
-                if: always() && steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework rebot -d results --merge results/output.xml results/rerun/rerun.xml
-
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-off/robot-ui/${GITHUB_RUN_ID}/PHP8.2MariaDB/group2/log.html
-
-            -   name: Slack Notification for failed job
-                uses: ./.github/actions/job-slack-notifications
-                if: always()
-
-    docker-alpine-php-82-postgresql-dynamic-store-off-robot-ui-group-three:
-        if: >
-            (github.event_name == 'pull_request'
-                && contains(github.event.pull_request.labels.*.name, 'run-compatibility-ci')
-            ) || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ssp-master'
-        name: "Docker / Alpine / PHP 8.2 / PostgreSQL / Dynamic Store OFF / Robot / UI / Group Three"
-        runs-on: ubuntu-latest
-        env:
-            PROGRESS_TYPE: plain
-            SPRYKER_PLATFORM_IMAGE: spryker/php:8.2
-            TRAVIS: 1
-            ROBOT_TESTS_ARTIFACTS_BUCKET_REGION: eu-west-1
-        steps:
-            -   uses: actions/checkout@v4
-
-            -   name: Install packages
-                run: |
-                    sudo apt-get update
-                    sudo apt-get install -y python3-pip
-                    pip3 install --upgrade pip
-                    pip3 install awscli
-
-            -   name: Install robotframework-suite-tests folder
-                run: |
-                    cd ./data && composer require "spryker/robotframework-suite-tests:dev-master" --dev --no-interaction
-                    cp -r vendor ../vendor
-
-            -   name: Install docker-compose
-                run: |
-                    sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-                    sudo chmod +x /usr/local/bin/docker-compose
-
-            -   name: Install Project
-                continue-on-error: false
-                run: |
-                    git clone https://github.com/spryker/docker-sdk.git ./docker
-                    docker/sdk boot deploy.ci.acceptance.dynamic-store-off.yml
-                    sudo bash -c "echo '127.0.0.1 backend-api.at.spryker.local backend-api.de.spryker.local glue-backend.de.spryker.local glue-backend.at.spryker.local glue-storefront.de.spryker.local glue-storefront.at.spryker.local backend-gateway.at.spryker.local backend-gateway.de.spryker.local backoffice.at.spryker.local backoffice.de.spryker.local date-time-configurator-example.spryker.local glue.at.spryker.local glue.de.spryker.local yves.at.spryker.local yves.de.spryker.local' >> /etc/hosts"
-                    docker/sdk up -t
-
-            -   name: Custom commands
-                continue-on-error: false
-                run: |
-                    docker/sdk cli composer dump-autoload -o -a --apcu
-                    APPLICATION_STORE=DE docker/sdk console queue:worker:start --stop-when-empty
-                    APPLICATION_STORE=AT docker/sdk console queue:worker:start --stop-when-empty
-
-            -   name: Run Tests
-                id: run_tests
-                continue-on-error: true
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results --exclude skip-due-to-issueORskip-due-to-refactoring --include group_tree -s '*'.tests.ui.b2b .
-                    docker/sdk exec robot-framework touch results/time.txt && echo $(date) > results/time.txt
-
-            -   name: Rerun Failed Tests
-                if: steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework robot -v is_ssp:true -v env:ui_b2b -v docker:True -v db_engine:psycopg2 -v headless:true -v ignore_console:false -d results/rerun --runemptysuite --rerunfailed results/output.xml --output rerun.xml -s '*'.tests.ui.b2b .
-
-            -   name: Merge Test Results
-                if: always() && steps.run_tests.outcome != 'success'
-                run: |
-                    docker/sdk exec robot-framework rebot -d results --merge results/output.xml results/rerun/rerun.xml
-
-            -   name: Upload artifacts
-                if: failure()
-                run: |
-                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-off/robot-ui/${GITHUB_RUN_ID}/PHP8.2MariaDB/group3/log.html
+                    AWS_DEFAULT_REGION=${{env.ROBOT_TESTS_ARTIFACTS_BUCKET_REGION}} AWS_ACCESS_KEY_ID=${{ secrets.ROBOT_TESTS_ARTIFACTS_KEY }} AWS_SECRET_ACCESS_KEY=${{ secrets.ROBOT_TESTS_ARTIFACTS_SECRET }} aws s3 cp .robot/results/log.html s3://${{vars.ROBOT_TESTS_ARTIFACTS_BUCKET}}/b2b/dms-off/robot-ui/${GITHUB_RUN_ID}/PHP8.2PostgreSQL/log.html
 
             -   name: Slack Notification for failed job
                 uses: ./.github/actions/job-slack-notifications

--- a/.robot/Dockerfile
+++ b/.robot/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt install -y \
 RUN pip3 install  \
     --no-cache-dir  \
     robotframework  \
+    robotframework-pabot  \
     robotframework-browser  \
     robotframework-databaselibrary  \
     robotframework-requests \

--- a/composer.lock
+++ b/composer.lock
@@ -76565,7 +76565,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/robotframework-suite-tests.git",
-                "reference": "cac93c3b00b0f622c316d4db58f7c9d01969ce4b"
+                "reference": "d9d7dd789776f256a9614ca28aa4fd8760021caa"
             },
             "default-branch": true,
             "type": "library",
@@ -76573,7 +76573,7 @@
                 "MIT"
             ],
             "description": "Automated tests for the Robot Framework",
-            "time": "2025-09-09T15:32:29+00:00"
+            "time": "2025-09-15T12:35:42+00:00"
         },
         {
             "name": "spryker/testify",


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/FRW-9914

###### Change log

- Enabled robotframework UI parallel tests execution in CI within one run

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
