### PR TITLE
Run evaluator only for release branches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
 
             -   name: Run Evaluator for release branches
                 run: vendor/bin/evaluator evaluate --format=compact
+                if: github.event.pull_request.base.ref == 'master' && startsWith(github.event.pull_request.head.ref, 'release-')
 
             -   name: Run Evaluator for all branches
                 run: vendor/bin/evaluator evaluate --exclude-checkers=SPRYKER_DEV_PACKAGES_CHECKER --format=compact


### PR DESCRIPTION
#### Overview

- Ticket: URL_HERE

###### Optional

- Core PR: URL_HERE

###### Change log

{Relevant changes for project level go here.}

###### CI Notice
Tests do **not** run automatically on every PR.
To trigger the required test suites, please add the appropriate label(s) to your PR.
For the full list of labels and their associated tests, see our Confluence page: [CI Test Labels & Triggers](https://spryker.atlassian.net/wiki/spaces/Framework/pages/4715216905/Using+PR+labels+to+control+CI+runs+for+project+repositories)
