### PR TITLE
CC-35770: Added blocker for brute force in discount (voucher) codes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9510,34 +9510,40 @@
         },
         {
             "name": "spryker-shop/cart-code-widget",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker-shop/cart-code-widget.git",
-                "reference": "2ba0a137d21badec839c937de12849e650341139"
+                "reference": "96b7004e87096732f5fe4215b3badc398767e43e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker-shop/cart-code-widget/zipball/2ba0a137d21badec839c937de12849e650341139",
-                "reference": "2ba0a137d21badec839c937de12849e650341139",
+                "url": "https://api.github.com/repos/spryker-shop/cart-code-widget/zipball/96b7004e87096732f5fe4215b3badc398767e43e",
+                "reference": "96b7004e87096732f5fe4215b3badc398767e43e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.3",
                 "spryker-shop/shop-application": "^1.0.0",
                 "spryker/application": "^3.8.0",
                 "spryker/cart-code": "^1.1.0",
+                "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/quote": "^2.8.0",
+                "spryker/security-blocker": "^1.0.0",
                 "spryker/symfony": "^3.1.0",
                 "spryker/zed-request": "^3.6.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
+                "spryker/event-dispatcher": "*",
                 "spryker/router": "*",
                 "spryker/silex": "*"
             },
             "suggest": {
+                "spryker/container": "Use this module when you want to use application services via ContainerInterface.",
+                "spryker/event-dispatcher": "Use this module when you want to register the SecurityBlockerCartCodeEventDispatcherPlugin.",
                 "spryker/router": "Use this module when you want to use the RouteProviderPlugin.",
                 "spryker/silex": "Use this module when using plugins that need Silex dependencies."
             },
@@ -9558,9 +9564,9 @@
             ],
             "description": "CartCodeWidget module",
             "support": {
-                "source": "https://github.com/spryker-shop/cart-code-widget/tree/1.6.0"
+                "source": "https://github.com/spryker-shop/cart-code-widget/tree/1.7.0"
             },
-            "time": "2024-05-22T10:49:07+00:00"
+            "time": "2026-05-21T08:39:14+00:00"
         },
         {
             "name": "spryker-shop/cart-note-widget",

--- a/data/import/common/common/glossary.csv
+++ b/data/import/common/common/glossary.csv
@@ -1197,6 +1197,8 @@ cart.voucher.apply.non_applicable,The voucher code is invalid,en_US
 cart.voucher.apply.non_applicable,Der Gutscheincode ist ungültig,de_DE
 cart.code.apply.failed,Code could not be applied,en_US
 cart.code.apply.failed,Gutscheincode konnte nicht angewendet werden,de_DE
+cart_code_widget.error.too_many_requests,Too many voucher code attempts. Please try again later.,en_US
+cart_code_widget.error.too_many_requests,Zu viele Versuche mit Gutscheincodes. Bitte versuchen Sie es später erneut.,de_DE
 cart.code.enter-code,Gutscheincode eingeben,de_DE
 cart.code.enter-code,Enter voucher code,en_US
 cart.item.bundle.description,Items in the bundle:,en_US

--- a/src/Pyz/Yves/EventDispatcher/EventDispatcherDependencyProvider.php
+++ b/src/Pyz/Yves/EventDispatcher/EventDispatcherDependencyProvider.php
@@ -29,6 +29,7 @@ use Spryker\Yves\Router\Plugin\EventDispatcher\RouterSslRedirectEventDispatcherP
 use Spryker\Yves\Session\Plugin\EventDispatcher\SaveSessionEventDispatcherPlugin;
 use Spryker\Yves\Session\Plugin\EventDispatcher\SessionEventDispatcherPlugin;
 use Spryker\Yves\Storage\Plugin\EventDispatcher\StorageCacheEventDispatcherPlugin;
+use SprykerShop\Yves\CartCodeWidget\Plugin\EventDispatcher\SecurityBlockerCartCodeEventDispatcherPlugin;
 use SprykerShop\Yves\ErrorPage\Plugin\EventDispatcher\ErrorPageEventDispatcherPlugin;
 use SprykerShop\Yves\SecurityBlockerPage\Plugin\EventDispatcher\SecurityBlockerAgentEventDispatcherPlugin;
 use SprykerShop\Yves\SecurityBlockerPage\Plugin\EventDispatcher\SecurityBlockerCustomerEventDispatcherPlugin;
@@ -68,6 +69,7 @@ class EventDispatcherDependencyProvider extends SprykerEventDispatcherDependency
             new ResponseListenerEventDispatcherPlugin(),
             new SecurityBlockerCustomerEventDispatcherPlugin(),
             new SecurityBlockerAgentEventDispatcherPlugin(),
+            new SecurityBlockerCartCodeEventDispatcherPlugin(),
             new EnvironmentInfoHeaderEventDispatcherPlugin(),
             new AnonymousIdSessionAssignEventDispatcherPlugin(),
         ];


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/CC-35770

###### Change log

Integrated security blocker for cart code (voucher) brute force protection:
- Added glossary entries for too many requests error message (en_US, de_DE)
- Registered SecurityBlockerCartCodeEventDispatcherPlugin in EventDispatcherDependencyProvider

###### CI Notice
**Additional tests** can be triggered by adding labels:
- `run-compatibility-ci` runs compatibility tests (PHP 8.3 / PostgreSQL / Debian / Prefer Lowest / Dynamic Store OFF):
    - Codeception / Acceptance & API
    - Codeception / Functional Tests
    - Robot / API
    - Robot / UI
    - Cypress / UI